### PR TITLE
Enable new notprod domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.terraform*
+tfplan

--- a/README.md
+++ b/README.md
@@ -14,27 +14,39 @@ We currently have 3 GitHub workflows.
 
 We’ve developed a habit of testing our changes in dev before raising them as a PR.
 
-You will need:
+**You will need:**
 
-- `brew install terraform`
+- Tools:
+  - The terraform CLI (install with brew)
+  - The AWS CLI
 - access to our k8s secrets to see the `ho-callisto-terraform-s3` secrets for configuring the back-end
-- The AWS cli
+- ‘ream-management’ client roles in keycloak for the callisto-dev realm (a colleague should be able to set you up here)
 
 Steps:
 
 1. `cd config`
 
 1. `terraform init`
-   …
 
-2. See what you’re changing with `terraform plan`:
+1. See what you’re changing with `terraform plan`:
 
-```
-KEYCLOAK_CLIENT_ID=terraform-client \
-KEYCLOAK_CLIENT_SECRET=[redacted] \
-KEYCLOAK_REALM=callisto-dev \
-KEYCLOAK_URL="https://sso-dev.notprod.homeoffice.gov.uk" \
-TF_VAR_callisto_realm=callisto-dev \
-TF_VAR_callisto_url=https://web.dev.callisto.homeoffice.gov.uk \
-terraform plan
-```
+   ```
+   KEYCLOAK_CLIENT_ID=terraform-client \
+   KEYCLOAK_CLIENT_SECRET=[redacted - grab from the keycloak realm management UI] \
+   KEYCLOAK_REALM=callisto-dev \
+   KEYCLOAK_URL="https://sso-dev.notprod.homeoffice.gov.uk" \
+   TF_VAR_callisto_realm=callisto-dev \
+   TF_VAR_callisto_url=https://web.dev.callisto.homeoffice.gov.uk \
+   terraform plan
+   ```
+
+1. Apply!:
+   ```
+   KEYCLOAK_CLIENT_ID=terraform-client \
+   KEYCLOAK_CLIENT_SECRET=[redacted - grab from the keycloak realm management UI] \
+   KEYCLOAK_REALM=callisto-dev \
+   KEYCLOAK_URL="https://sso-dev.notprod.homeoffice.gov.uk" \
+   TF_VAR_callisto_realm=callisto-dev \
+   TF_VAR_callisto_url=https://web.dev.callisto.homeoffice.gov.uk \
+   terraform apply
+   ```

--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ Steps:
    TF_VAR_callisto_url=https://web.dev.callisto.homeoffice.gov.uk \
    terraform apply
    ```
+
+### Troubleshooting
+
+Your terraform plan might want to recreate a load of `data.keycloak_openid_client.realm_management` stuff. We’re still trying to figure out exactly why this is. In the meantime, our workaround is to target specific resources to create, e.g. `… terraform plan -target=keycloak_openid_client.react_client`

--- a/README.md
+++ b/README.md
@@ -1,10 +1,40 @@
 # Callisto Auth Keycloak
+
 This project contains the configuration that needs to be applied to Callisto's Keycloak realm.
 
 The configuration is held in Terraform so that we can create repeatable deployments across environments.
 
-We currently have 3 GitHub workflows. 
+We currently have 3 GitHub workflows.
 
 - Pushes to branches trigger a workflow flow to validate the terraform and check it's formatting
 - Merges into main trigger a workflow that applies the terraform configuration
 - A nightly workflow runs a terraform plan with a detailed exit code which causes a failure if any changes are detected
+
+## Testing changes from your local before raising PR
+
+We’ve developed a habit of testing our changes in dev before raising them as a PR.
+
+You will need:
+
+- `brew install terraform`
+- access to our k8s secrets to see the `ho-callisto-terraform-s3` secrets for configuring the back-end
+- The AWS cli
+
+Steps:
+
+1. `cd config`
+
+1. `terraform init`
+   …
+
+2. See what you’re changing with `terraform plan`:
+
+```
+KEYCLOAK_CLIENT_ID=terraform-client \
+KEYCLOAK_CLIENT_SECRET=[redacted] \
+KEYCLOAK_REALM=callisto-dev \
+KEYCLOAK_URL="https://sso-dev.notprod.homeoffice.gov.uk" \
+TF_VAR_callisto_realm=callisto-dev \
+TF_VAR_callisto_url=https://web.dev.callisto.homeoffice.gov.uk \
+terraform plan
+```

--- a/config/main.tf
+++ b/config/main.tf
@@ -26,7 +26,7 @@ resource "keycloak_realm" "callisto" {
   security_defenses {
     headers {
       x_frame_options                     = "SAMEORIGIN"
-      content_security_policy             = "frame-src 'self'; frame-ancestors 'self' ${var.callisto_url}; object-src 'none';"
+      content_security_policy             = "frame-src 'self'; frame-ancestors 'self' https://web.dev.callisto.homeoffice.gov.uk/ https://web.dev.callisto-notprod.homeoffice.gov.uk/; object-src 'none';"
       content_security_policy_report_only = ""
       x_content_type_options              = "nosniff"
       x_robots_tag                        = "none"

--- a/config/react-client.tf
+++ b/config/react-client.tf
@@ -19,9 +19,11 @@ resource "keycloak_openid_client" "react_client" {
   root_url  = "https://web.dev.callisto.homeoffice.gov.uk/"
   valid_redirect_uris = [
     "https://web.dev.callisto.homeoffice.gov.uk/*",
+    "https://web.dev.callisto-notprod.homeoffice.gov.uk/*",
   ]
   web_origins = [
     "https://web.dev.callisto.homeoffice.gov.uk",
+    "https://web.dev.callisto-notprod.homeoffice.gov.uk",
   ]
 }
 

--- a/config/react-client.tf
+++ b/config/react-client.tf
@@ -15,15 +15,13 @@ resource "keycloak_openid_client" "react_client" {
   direct_access_grants_enabled             = true
   service_accounts_enabled                 = false
 
-  admin_url = "https://web.dev.callisto-notprod.homeoffice.gov.uk/"
-  root_url  = "https://web.dev.callisto-notprod.homeoffice.gov.uk/"
+  admin_url = "https://web.dev.callisto.homeoffice.gov.uk/"
+  root_url  = "https://web.dev.callisto.homeoffice.gov.uk/"
   valid_redirect_uris = [
     "https://web.dev.callisto.homeoffice.gov.uk/*",
-    "https://web.dev.callisto-notprod.homeoffice.gov.uk/*",
   ]
   web_origins = [
     "https://web.dev.callisto.homeoffice.gov.uk",
-    "https://web.dev.callisto.homeoffice-notprod.gov.uk",
   ]
 }
 

--- a/config/react-client.tf
+++ b/config/react-client.tf
@@ -15,13 +15,15 @@ resource "keycloak_openid_client" "react_client" {
   direct_access_grants_enabled             = true
   service_accounts_enabled                 = false
 
-  admin_url = "https://web.dev.callisto.homeoffice.gov.uk/"
-  root_url  = "https://web.dev.callisto.homeoffice.gov.uk/"
+  admin_url = "https://web.dev.callisto-notprod.homeoffice.gov.uk/"
+  root_url  = "https://web.dev.callisto-notprod.homeoffice.gov.uk/"
   valid_redirect_uris = [
     "https://web.dev.callisto.homeoffice.gov.uk/*",
+    "https://web.dev.callisto-notprod.homeoffice.gov.uk/*",
   ]
   web_origins = [
     "https://web.dev.callisto.homeoffice.gov.uk",
+    "https://web.dev.callisto.homeoffice-notprod.gov.uk",
   ]
 }
 

--- a/config/react-client.tf
+++ b/config/react-client.tf
@@ -15,8 +15,6 @@ resource "keycloak_openid_client" "react_client" {
   direct_access_grants_enabled             = true
   service_accounts_enabled                 = false
 
-  admin_url = "https://web.dev.callisto.homeoffice.gov.uk/"
-  root_url  = "https://web.dev.callisto.homeoffice.gov.uk/"
   valid_redirect_uris = [
     "https://web.dev.callisto.homeoffice.gov.uk/*",
     "https://web.dev.callisto-notprod.homeoffice.gov.uk/*",


### PR DESCRIPTION
Was going to do a straight switch but saw an opportunity to do it the non-breaking way

Stephen’s PR turns the URL into a variable, which is of course incompatible with this change: https://github.com/UKHomeOffice/callisto-auth-keycloak/pull/8

My plan is to get this going and then switch back to just the new URL afterwards

Bonus: some readme additions