### PR TITLE
Eahw 2589/terraform reduce url security

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -9,6 +9,12 @@ on:
 
 jobs:
   terraform-validate:
+    strategy:
+      matrix:
+        stage: ['development', 'test', 'production']
+    # set the environment to use (environment must exist and be named the same as the stage here)
+    environment:
+      name: ${{ matrix.stage }}
     defaults:
       run:
         working-directory: ./config

--- a/config/main.tf
+++ b/config/main.tf
@@ -26,7 +26,7 @@ resource "keycloak_realm" "callisto" {
   security_defenses {
     headers {
       x_frame_options                     = "SAMEORIGIN"
-      content_security_policy             = "frame-src 'self'; frame-ancestors 'self' %{ if var.callisto_url != ""}${var.callisto_url}%{ else }*%{ endif }; object-src 'none';"
+      content_security_policy             = "frame-src 'self'; frame-ancestors 'self' %{if var.callisto_url != ""}${var.callisto_url}%{else}*%{endif}; object-src 'none';"
       content_security_policy_report_only = ""
       x_content_type_options              = "nosniff"
       x_robots_tag                        = "none"

--- a/config/main.tf
+++ b/config/main.tf
@@ -26,7 +26,7 @@ resource "keycloak_realm" "callisto" {
   security_defenses {
     headers {
       x_frame_options                     = "SAMEORIGIN"
-      content_security_policy             = "frame-src 'self'; frame-ancestors 'self' ${var.callisto_url}; object-src 'none';"
+      content_security_policy             = "frame-src 'self'; frame-ancestors 'self' %{ if var.callisto_url != ""}${var.callisto_url}%{ else }*%{ endif }; object-src 'none';"
       content_security_policy_report_only = ""
       x_content_type_options              = "nosniff"
       x_robots_tag                        = "none"

--- a/config/react-client.tf
+++ b/config/react-client.tf
@@ -15,11 +15,11 @@ resource "keycloak_openid_client" "react_client" {
   direct_access_grants_enabled             = true
   service_accounts_enabled                 = false
 
-  valid_redirect_uris = [    
-    var.callisto_url != "" ? "${var.callisto_url}/*" : "*"
+  valid_redirect_uris = [
+    var.callisto_url != "" ? "${var.callisto_url}/*" : "*",
   ]
-  web_origins = [    
-    var.callisto_url != "" ? var.callisto_url : "*"
+  web_origins = [
+    var.callisto_url != "" ? var.callisto_url : "*",
   ]
 }
 

--- a/config/react-client.tf
+++ b/config/react-client.tf
@@ -15,11 +15,11 @@ resource "keycloak_openid_client" "react_client" {
   direct_access_grants_enabled             = true
   service_accounts_enabled                 = false
 
-  valid_redirect_uris = [
-    "${var.callisto_url}/*",
+  valid_redirect_uris = [    
+    var.callisto_url != "" ? "${var.callisto_url}/*" : "*"
   ]
-  web_origins = [
-    var.callisto_url,
+  web_origins = [    
+    var.callisto_url != "" ? var.callisto_url : "*"
   ]
 }
 


### PR DESCRIPTION
Terraform change to look for an empty callisto_url variable and reduce the Keycloak security to allow any:
- Redirect url
- Origin url
- Frame ancestor url

Also, an update to the terraform-validate job to run the validation checks against every environment.