### PR TITLE
Remove production from terraform files

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,7 @@ jobs:
   terraform-plan-and-apply:
     strategy:
       matrix:
-        stage: ['development', 'test', 'production']
+        stage: ['development', 'test'] # Add stage ['production'] to reinstate production deployment
       # When set to true, GitHub cancels all in-progress jobs if any matrix job fails.
       fail-fast: true
       # The maximum number of jobs that can run simultaneously

--- a/.github/workflows/schedule.yaml
+++ b/.github/workflows/schedule.yaml
@@ -9,7 +9,7 @@ jobs:
   terraform-plan-and-apply:
     strategy:
       matrix:
-        stage: ['development', 'test', 'production']
+        stage: ['development', 'test'] # Add stage ['production'] to reinstate production deployment
       # When set to true, GitHub cancels all in-progress jobs if any matrix job fails.
       fail-fast: true
       # The maximum number of jobs that can run simultaneously

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -11,7 +11,7 @@ jobs:
   terraform-validate:
     strategy:
       matrix:
-        stage: ['development', 'test', 'production']
+        stage: ['development', 'test'] # Add stage ['production'] to reinstate production deployment
     # set the environment to use (environment must exist and be named the same as the stage here)
     environment:
       name: ${{ matrix.stage }}


### PR DESCRIPTION
This PR removes the production environment from the terraform files.
This is because the keycloak realm has now been deleted